### PR TITLE
feat(api): prefix with v1

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,11 +23,13 @@ app.use("/:workspaceId/*", async (c, next) => {
   }
 
   const workspaceRoutes = ["/tags", "/categories", "/posts", "/authors"];
-  const isWorkspaceRoute = workspaceRoutes.some(
-    (route) =>
-      path.includes(`/${workspaceId}${route}`) ||
-      path.match(new RegExp(`/${workspaceId}${route}/`)),
-  );
+  const workspacePathPattern = `/${workspaceId}`;
+
+  const isWorkspaceRoute = workspaceRoutes.some((route) => {
+    const exactMatch = path === `${workspacePathPattern}${route}`;
+    const subPathMatch = path.startsWith(`${workspacePathPattern}${route}/`);
+    return exactMatch || subPathMatch;
+  });
 
   if (isWorkspaceRoute) {
     const newPath = `/v1${path}`;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -376,17 +376,17 @@ v1.get("/:workspaceId/posts", async (c) => {
   }
 });
 
-v1.get("/:workspaceId/posts/:slug", async (c) => {
+v1.get("/:workspaceId/posts/:identifier", async (c) => {
   try {
     const url = c.env.DATABASE_URL;
     const workspaceId = c.req.param("workspaceId");
-    const slug = c.req.param("slug");
+    const identifier = c.req.param("identifier");
     const db = createClient(url);
 
     const post = await db.post.findFirst({
       where: {
         workspaceId,
-        slug,
+        OR: [{ slug: identifier }, { id: identifier }],
         status: "published",
       },
       select: {


### PR DESCRIPTION
This prefixes the API routes with /v1 and adds a middleware to ensure old requests are properly redirected!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-related API endpoints are now organized under a versioned `/v1` path for improved clarity.
* **Refactor**
  * Existing workspace routes have been moved to the new `/v1` namespace.
* **Bug Fixes**
  * Requests to old workspace routes are automatically redirected to their new `/v1` versions, ensuring backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->